### PR TITLE
feat: Add additional build arguments

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yml
+++ b/.github/workflows/reusable-docker-build-push.yml
@@ -245,6 +245,11 @@ jobs:
             IMAGE_CREATED_DATETIME=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.created'] }}
             IMAGE_VERSION=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.version'] }}
             IMAGE_REVISION=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            REPOSITORY=${{ github.repository }}
+            GIT_COMMIT_SHA=${{ github.sha }}
+            GIT_BEFORE_SHA=${{ github.event.before }}
+            GIT_AFTER_SHA=${{ github.event.after }}
+            WORKFLOW_RUN_ID=${{ github.run_id }}
             ${{ inputs.build_args }}
           secrets: ${{ secrets.DOCKER_SECRETS }}
 


### PR DESCRIPTION
Added new build arguments to provide more detailed context in the build process. These include:

- Repository Name: To identify the source repository.
- Commit SHA: Specific identifier for the commit.
- Before SHA and After SHA: Identifiers for the commits before and after the change.
- Workflow Run ID: Unique identifier for the workflow execution.

These build arguments are especially useful for enhancing Prometheus info metrics, enabling detailed tracking in Grafana back to the source.
