### PR TITLE
feat: Add image digest metadata as build arg

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yml
+++ b/.github/workflows/reusable-docker-build-push.yml
@@ -247,6 +247,7 @@ jobs:
             IMAGE_CREATED_DATETIME=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.created'] }}
             IMAGE_VERSION=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.version'] }}
             IMAGE_REVISION=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            IMAGE_DIGEST=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.digest'] }}
             GITHUB_REPOSITORY=${{ github.repository }}
             GIT_COMMIT_SHA=${{ github.sha }}
             GIT_BEFORE_SHA=${{ github.event.before }}


### PR DESCRIPTION
## Motivation and Context

To be able to add links in Grafana to ECR, which is on the form

https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/xxxxxxxxxxxx/env/_/image/sha256:3ffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/details?region=eu-west-1

the workflow needs to add the image digest as a build arg.