### PR TITLE
fix: Remove non-functional IMAGE_DIGEST

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yml
+++ b/.github/workflows/reusable-docker-build-push.yml
@@ -66,7 +66,7 @@ on:
 
       build_args:
         description: >
-          List of build-time variables. `IMAGE_CREATED_DATETIME`, `IMAGE_VERSION`, `IMAGE_REVISION` and `IMAGE_DIGEST` are added automatically.
+          List of build-time variables. `IMAGE_CREATED_DATETIME`, `IMAGE_VERSION` and `IMAGE_REVISION` are added automatically.
         required: false
         type: string
 
@@ -247,7 +247,6 @@ jobs:
             IMAGE_CREATED_DATETIME=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.created'] }}
             IMAGE_VERSION=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.version'] }}
             IMAGE_REVISION=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-            IMAGE_DIGEST=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.digest'] }}
             GITHUB_REPOSITORY=${{ github.repository }}
             GIT_COMMIT_SHA=${{ github.sha }}
             GIT_BEFORE_SHA=${{ github.event.before }}


### PR DESCRIPTION
The docker-meta output cannot possibly contain the image digest, since it is only known after building an image.

https://github.com/oslokommune/reusable-docker-build-push/blob/284b1ff99d557b0bbec8a729bf84a0b29b9b3a20/.github/workflows/reusable-docker-build-push.yml#L250

Image digest is an output of the build-push step, so it cannot be used as a docker build arg.