### PR TITLE
feat: Add support for npm cache

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yml
+++ b/.github/workflows/reusable-docker-build-push.yml
@@ -174,6 +174,20 @@ on:
         type: string
         default: '**/requirements.txt'
 
+      npm_cache:
+        description: |
+          Enable or disable the use of a persistent npm directory cache.
+
+          Mount the cache into the container using the `--mount` flag with the `RUN` instruction in the Dockerfile. The cache must be in the default location (`/root/.npm`) and have an ID of `npm-cache`.
+        default: false
+        type: boolean
+
+      npm_package_file_pattern:
+        description: >
+          Glob pattern to match the npm package file.
+        type: string
+        default: '**/package.json'
+
     outputs:
 
       image_version:
@@ -366,6 +380,33 @@ jobs:
             }
           save-always: "false"
           skip-extraction: ${{ steps.cache-pip.outputs.cache-hit }}
+
+
+      - if: ${{ inputs.npm_cache }}
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        name: Handle cache for npm ⚙
+        id: cache-npm
+        with:
+          key: cache-npm-${{ hashFiles(inputs.npm_package_file_pattern) }}
+          path: |
+            root-npm
+          restore-keys: |
+            cache-npm-
+
+
+      - if: ${{ inputs.npm_cache }}
+        name: Inject npm cache into Docker ⚙
+        uses: reproducible-containers/buildkit-cache-dance@87e6a3bbd976a1476e29b60fe743ab0977034ff5 # v3.1.1
+        with:
+          cache-map: |
+            {
+              "root-npm": {
+                "target": "/root/.npm",
+                "id": "npm-cache"
+              }
+            }
+          save-always: "false"
+          skip-extraction: ${{ steps.cache-npm.outputs.cache-hit }},
 
 
       - name: Build and push (if enabled) Docker image to one or more registries 🚀


### PR DESCRIPTION
feat: Add support for npm cache.

## Random notes

Remove any `USER` instructions that make no difference because it's a multi stage build.

```
RUN --mount=type=cache,id=npm-cache,sharing=locked,target=/root/.npm \
    npm clean-install
```

Also:

```
FROM nginxinc/nginx-unprivileged:1.27-alpine3.19-slim@sha256:40e17e5d27afecf49dd3545389bc57e9a79fe379cb4934cd0639727cdb638954 AS final
```

Also:

```
  mount_points = [
    {
      sourceVolume  = "init-etc-nginx"
      containerPath = "/etc/nginx"
      readOnly      = false
    },
    {
      sourceVolume  = "init-var-cache-nginx"
      containerPath = "/var/cache/nginx"
      readOnly      = false
    },
    {
      sourceVolume  = "init-tmp"
      containerPath = "/tmp"
      readOnly      = false
    }
  ]
```

Also:

The init container.

Also:

```
  additional_main_container_dependencies = [{
    containerName = "set-mount-permissions"
    condition     = "SUCCESS"
  }]

  additional_container_definitions = {
    init_container                = local.init_container                # Changes permissions of directories that can't be read only
  }
```