### PR TITLE
Skip installing QEMU if runner is ARM64

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yml
+++ b/.github/workflows/reusable-docker-build-push.yml
@@ -343,7 +343,7 @@ jobs:
           tags: ${{ inputs.tag_rules }}
 
 
-      - if: ${{ inputs.platforms != 'linux/amd64' }}
+      - if: ${{ inputs.platforms != 'linux/amd64' && runner.arch != 'ARM64' }}
         name: Set up QEMU (Quick EMUlator) for multi-platform images ⚙️
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 


### PR DESCRIPTION
No need to install QEMU if we already are running om ARM