### PR TITLE
fix: log contents of downloaded artifact directory

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yml
+++ b/.github/workflows/reusable-docker-build-push.yml
@@ -332,12 +332,20 @@ jobs:
 
 
       - if: inputs.download_artifact
+        id: download-artifact
         name: Download artifacts 📦
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: ${{ inputs.download_artifact_name }}
           path: ${{ inputs.download_artifact_path }}
           merge-multiple: true
+
+
+      - if: inputs.download_artifact
+        name: List downloaded artifact(s) 📦
+        run: ls -R -- "$DOWNLOAD_PATH"
+        env:
+          DOWNLOAD_PATH: ${{ steps.download-artifact.outputs.download-path }}
 
 
       - name: Extract metadata (tags, labels) from Git reference and GitHub events ⚙️


### PR DESCRIPTION
## Summary

- Adds a step that recursively lists files under the downloaded artifact directory when `inputs.download_artifact` is true, so it's visible in the workflow logs what was actually fetched.
- Uses the `download-path` output from `actions/download-artifact@v6` so no fallback logic is needed when `inputs.download_artifact_path` is empty.
- Passes the path via `env:` and quotes it in the shell command to avoid shell injection through the path value.