### PR TITLE
feat: expose merge-multiple as input to download-artifact

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yml
+++ b/.github/workflows/reusable-docker-build-push.yml
@@ -72,8 +72,9 @@ on:
 
       download_artifact_merge_multiple:
         description: >
-          Input passed to actions/download-artifact. See
-          https://github.com/actions/download-artifact#inputs
+          When multiple artifacts are matched, controls the destination layout. If true, all artifacts are extracted
+          into the same `path`; if false, each artifact gets its own named subdirectory. Ignored when downloading a
+          single artifact by name. See https://github.com/actions/download-artifact#inputs
         required: false
         type: boolean
         default: true

--- a/.github/workflows/reusable-docker-build-push.yml
+++ b/.github/workflows/reusable-docker-build-push.yml
@@ -70,6 +70,14 @@ on:
         required: false
         type: string
 
+      download_artifact_merge_multiple:
+        description: >
+          Input passed to actions/download-artifact. See
+          https://github.com/actions/download-artifact#inputs
+        required: false
+        type: boolean
+        default: true
+
       context:
         description: >
           Docker context (path) to start build from.
@@ -337,7 +345,7 @@ jobs:
         with:
           name: ${{ inputs.download_artifact_name }}
           path: ${{ inputs.download_artifact_path }}
-          merge-multiple: true
+          merge-multiple: ${{ inputs.download_artifact_merge_multiple }}
 
 
       - name: Extract metadata (tags, labels) from Git reference and GitHub events ⚙️


### PR DESCRIPTION
## Description

Expose `merge-multiple` as a new input `download_artifact_merge_multiple` on the reusable workflow, wired through to `actions/download-artifact`. Default is `true` to preserve existing behavior.

## Motivation and Context

The workflow currently hardcodes `merge-multiple: true`. When a job downloads multiple artifacts whose internal folder structure collides (e.g. an `amd64` artifact containing `main` and an `arm64` artifact containing `main`), the files are silently merged into the same path and one overwrites the other.

With this change, callers that hit such collisions can pass `download_artifact_merge_multiple: false` and get each artifact under its own subdirectory.

See the action's input docs: https://github.com/actions/download-artifact#inputs

[Slack-thread](https://oslokommune.slack.com/archives/C06A1NDQMN1/p1778670144601159).