### PR TITLE
fix: scope GHA build cache and tolerate cache export errors

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yml
+++ b/.github/workflows/reusable-docker-build-push.yml
@@ -177,6 +177,16 @@ on:
         required: false
         type: string
 
+      cache_scope:
+        description: |
+          The scope to use for the GitHub Actions build cache.
+
+          Builds sharing a scope share cache entries, and concurrent builds writing the same layers to the same scope can conflict.
+
+          Default is the ECR repository name, or the GitHub repository name if that is not set.
+        required: false
+        type: string
+
       gradle_cache:
         description: |
           Enable or disable the use of a persistent Gradle directory cache.
@@ -517,6 +527,13 @@ jobs:
           skip-extraction: ${{ steps.cache-go.outputs.cache-hit }}
 
 
+      - name: Set build cache scope ⚙
+        # Sanitized to [A-Za-z0-9_.-] to prevent injection of extra cache-to/cache-from attributes.
+        env:
+          RAW_CACHE_SCOPE: ${{ inputs.cache_scope || inputs.ecr_repository_name || github.event.repository.name }}
+        run: echo "CACHE_SCOPE=$(printf '%s' "$RAW_CACHE_SCOPE" | tr -c 'A-Za-z0-9_.-' '-')" >> "$GITHUB_ENV"
+
+
       - name: Build and push (if enabled) Docker image to one or more registries 🚀
         id: build-push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -543,8 +560,9 @@ jobs:
           secrets: ${{ secrets.DOCKER_SECRETS }}
 
           # https://docs.docker.com/build/ci/github-actions/examples/#cache
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Separate cache scopes keep concurrent builds from racing, ignore-error keeps cache export failures non-fatal.
+          cache-from: type=gha,scope=${{ env.CACHE_SCOPE }}
+          cache-to: type=gha,mode=max,ignore-error=true,scope=${{ env.CACHE_SCOPE }}
 
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}

--- a/.github/workflows/reusable-docker-build-push.yml
+++ b/.github/workflows/reusable-docker-build-push.yml
@@ -179,9 +179,9 @@ on:
 
       cache_scope:
         description: |
-          The scope to use for the GitHub Actions build cache.
+          The scope to use for the Docker build cache stored in the GitHub Actions cache backend (`type=gha`).
 
-          Builds sharing a scope share cache entries, and concurrent builds writing the same layers to the same scope can conflict.
+          Builds sharing a scope share cached layers, and concurrent builds writing the same layers to the same scope can conflict.
 
           Default is the ECR repository name, or the GitHub repository name if that is not set.
         required: false


### PR DESCRIPTION
Fixes #196

## Problem

When a repository runs multiple concurrent builds via this workflow, the builds race each other writing identical layer blobs to the shared default GHA cache scope. The losing build fails with:

```
#34 exporting to GitHub Actions Cache
#34 ERROR: error writing layer blob: failed to reserve cache
ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache
```

This fails the job **after** the image has been successfully built and pushed, blocking downstream deploy jobs over a failed write to what is purely an optimization. See #196 for the full analysis and evidence from `origo-booking`, where every PR-merge-triggered deploy fails this way (confirmed on both this workflow and the deprecated `reusable-workflows` predecessor, which has the identical cache config).

## Changes

1. **`ignore-error=true` on `cache-to`** — a failed cache export logs a warning instead of failing an otherwise successful build+push. Worst case is a cache-cold next build.
2. **`scope=` on `cache-from`/`cache-to`** — defaults to `ecr_repository_name`, falling back to the repository name (same convention the workflow already uses for `ecr_repository_name` itself). Concurrent builds of different images stop colliding, and each image gets its own effective cache instead of all builds thrashing one scope.
3. **New optional `cache_scope` input** — takes precedence over the default when callers need finer control (e.g. GHCR-only monorepos where `ecr_repository_name` is unset).

## Impact on existing consumers

- **No breaking changes** — no new required inputs, no output changes.
- **One-time cache-cold build** after upgrading: the scope is part of the cache key, so the first build starts from an empty cache. The old `buildkit`-scoped entries age out via normal GitHub cache eviction.
- Repos building a single image are otherwise unaffected: `scope=<name>` behaves identically to the previous default, and `ignore-error` only activates when cache export fails (which previously failed their build).
- Repos building multiple images get the fix plus better cache hit rates.

## Security

The scope value is resolved into an env var and sanitized to `[A-Za-z0-9_.-]` before use, so it cannot inject additional comma-separated cache configuration attributes (e.g. `url=`/`token=`) even if a caller wires untrusted data (such as a branch name) into `cache_scope`. Verified: `x,url=https://evil.example,token=abc` → `x-url-https---evil.example-token-abc`.

## Testing

- `actionlint` passes on the modified workflow
- Sanitizer verified against malicious and normal inputs (normal scopes like `prod-public` pass through unchanged)
